### PR TITLE
Removing cypress from CI (#27)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  cypress: cypress-io/cypress@1.13.0
 jobs:
   build:
     # pre-built images: https://circleci.com/docs/2.0/circleci-images/
@@ -52,21 +50,9 @@ workflows:
         - test:
             requires:
               - build
-        - cypress/run:
-            start: npm run start
-            wait-on: 'http://127.0.0.1:8080'
-            requires:
-              - build
-            filters:
-              branches:
-                only:
-                  - master
-                  - staging
-                  - production
         - deployment:
             requires:
               - test
-              - cypress/run
             filters:
               branches:
                 only:

--- a/src/js/glow-process/final-pass-shader.ts
+++ b/src/js/glow-process/final-pass-shader.ts
@@ -34,7 +34,6 @@ const FinalShaderPass = {
 
     "void main(){",
       "gl_FragColor = (getTexture(texOne) + vec4(1.0) * getTexture(glowTexture));",
-      //"gl_FragColor = (texture2D(texOne, vUv));",
     "}"
 
   ].join("\n")


### PR DESCRIPTION
* Removing "isClosed" class from card as default, shader naming fix

* Removing cypress from CI

While "reasonable" to have this in the pipeline, it's unreliable given the amount of webgl. Not really testing what the user is seeing and causes tests to fail so what's the point.